### PR TITLE
Support base64 input

### DIFF
--- a/src/predict.py
+++ b/src/predict.py
@@ -96,14 +96,14 @@ class Predictor:
 
         segments = list(segments)
 
-        # if transcription == "plain_text":
-        #     transcription = result["text"]
+        if transcription == "plain_text":
+           transcription = "".join([segment.text for segment in segments])
         # elif transcription == "srt":
         #     transcription = write_srt(result["segments"])
         # else:
         #     transcription = write_vtt(result["segments"])
 
-        if transcription == "srt":
+        elif transcription == "srt":
             transcription = write_srt(segments)
         else:
             transcription = write_vtt(segments)

--- a/src/predict.py
+++ b/src/predict.py
@@ -97,7 +97,7 @@ class Predictor:
         segments = list(segments)
 
         if transcription == "plain_text":
-           transcription = "".join([segment.text for segment in segments])
+            transcription = "\n".join([segment.text.lstrip() for segment in segments])
         # elif transcription == "srt":
         #     transcription = write_srt(result["segments"])
         # else:
@@ -117,6 +117,8 @@ class Predictor:
             "detected_language": info.language,
             "transcription": transcription,
             "translation": write_srt(translation_segments) if translate else None,
+            "device": "cuda" if rp_cuda.is_available() else "cpu",
+            "model": model_name,
         }
 
 

--- a/src/rp_handler.py
+++ b/src/rp_handler.py
@@ -56,9 +56,11 @@ def run_whisper_job(job):
             return {"error": input_validation['errors']}
         job_input = input_validation['validated_input']
 
-    # with rp_debugger.LineTimer('download_step'):
-    #    job_input['audio'] = download_files_from_urls(job['id'], [job_input['audio']])[0]
-    job_input['audio'] = base64_to_tempfile(job_input['audio'])
+    if job_input['audio'].startswith('http'):
+        with rp_debugger.LineTimer('download_step'):
+            job_input['audio'] = download_files_from_urls(job['id'], [job_input['audio']])[0]
+    else:
+        job_input['audio'] = base64_to_tempfile(job_input['audio'])
 
     with rp_debugger.LineTimer('prediction_step'):
         whisper_results = MODEL.predict(

--- a/src/rp_handler.py
+++ b/src/rp_handler.py
@@ -17,6 +17,25 @@ MODEL = predict.Predictor()
 MODEL.setup()
 
 
+def base64_to_tempfile(base64_file: str) -> str:
+    '''
+    Convert base64 file to tempfile.
+
+    Parameters:
+    base64_file (str): Base64 file
+
+    Returns:
+    str: Path to tempfile
+    '''
+    import base64
+    import tempfile
+
+    with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as temp_file:
+        temp_file.write(base64.b64decode(base64_file))
+
+    return temp_file.name
+
+
 @rp_debugger.FunctionTimer
 def run_whisper_job(job):
     '''
@@ -39,6 +58,7 @@ def run_whisper_job(job):
 
     # with rp_debugger.LineTimer('download_step'):
     #    job_input['audio'] = download_files_from_urls(job['id'], [job_input['audio']])[0]
+    job_input['audio'] = base64_to_tempfile(job_input['audio'])
 
     with rp_debugger.LineTimer('prediction_step'):
         whisper_results = MODEL.predict(

--- a/src/rp_handler.py
+++ b/src/rp_handler.py
@@ -37,8 +37,8 @@ def run_whisper_job(job):
             return {"error": input_validation['errors']}
         job_input = input_validation['validated_input']
 
-    with rp_debugger.LineTimer('download_step'):
-        job_input['audio'] = download_files_from_urls(job['id'], [job_input['audio']])[0]
+    # with rp_debugger.LineTimer('download_step'):
+    #    job_input['audio'] = download_files_from_urls(job['id'], [job_input['audio']])[0]
 
     with rp_debugger.LineTimer('prediction_step'):
         whisper_results = MODEL.predict(


### PR DESCRIPTION
I have built an image with the new changes, in case you want to try it:
https://hub.docker.com/layers/leandroalbero/whisper-fast/dev/images/sha256-5848d6ddd61f3ca7fa5e3f4ce697c6806645a7c04f56dfe49223723dc49df743
Here's a postman call to the updated endpoint with a base64 input:
![image](https://github.com/runpod-workers/worker-faster_whisper/assets/12993089/edc12b4e-ef8a-4d43-93ee-98000f119b39)
And here with an audio URL:
![image](https://github.com/runpod-workers/worker-faster_whisper/assets/12993089/ce0110e2-e11a-46ad-8274-63db347e6ee1)

I have some doubts with those lines, should we add an `rp_debugger`?
https://github.com/runpod-workers/worker-faster_whisper/blob/79d45b3ad72a9ae70f8e6aa26c646ba9ef2cbe24/src/rp_handler.py#L59-L63