### PR TITLE
Update docs, add VAD option and extra format

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,25 +12,27 @@ This repository contains the [Faster Whisper](https://github.com/guillaumekln/fa
 
 ## Model Inputs
 
-| Input                               | Type  | Description                                                                                                 |
-|-------------------------------------|-------|-------------------------------------------------------------------------------------------------------------|
-| `audio`                             | Path  | Audio file                                                                                                  |
-| `model`                             | str   | Choose a Whisper model. Choices: "tiny", "base", "small", "medium", "large-v1", "large-v2". Default: "base" |
-| `transcription`                     | str   | Choose the format for the transcription. Choices: "plain text", "srt", "vtt". Default: "plain text"         |
-| `translate`                         | bool  | Translate the text to English when set to True. Default: False                                              |
-| `language`                          | str   | Language spoken in the audio, specify None to perform language detection. Default: None                     |
-| `temperature`                       | float | Temperature to use for sampling. Default: 0                                                                 |
-| `best_of`                           | int   | Number of candidates when sampling with non-zero temperature. Default: 5                                    |
-| `beam_size`                         | int   | Number of beams in beam search, only applicable when temperature is zero. Default: 5                        |
-| `patience`                          | float | Optional patience value to use in beam decoding. Default: None                                              |
-| `length_penalty`                    | float | Optional token length penalty coefficient (alpha). Default: None                                            |
-| `suppress_tokens`                   | str   | Comma-separated list of token ids to suppress during sampling. Default: "-1"                                |
-| `initial_prompt`                    | str   | Optional text to provide as a prompt for the first window. Default: None                                    |
-| `condition_on_previous_text`        | bool  | If True, provide the previous output of the model as a prompt for the next window. Default: True            |
-| `temperature_increment_on_fallback` | float | Temperature to increase when falling back when the decoding fails. Default: 0.2                             |
-| `compression_ratio_threshold`       | float | If the gzip compression ratio is higher than this value, treat the decoding as failed. Default: 2.4         |
-| `logprob_threshold`                 | float | If the average log probability is lower than this value, treat the decoding as failed. Default: -1.0        |
-| `no_speech_threshold`               | float | If the probability of the token is higher than this value, consider the segment as silence. Default: 0.6    |
+| Input                               | Type  | Description                                                                                                                                              |
+|-------------------------------------|-------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `audio`                             | Path  | Audio file                                                                                                                                               |
+| `audio_base64`                      | str   | Base64-encoded audio file                                                                                                                                |
+| `model`                             | str   | Choose a Whisper model. Choices: "tiny", "base", "small", "medium", "large-v1", "large-v2". Default: "base"                                              |
+| `transcription`                     | str   | Choose the format for the transcription. Choices: "plain_text", "formatted_text", "srt", "vtt". Default: "plain_text"                                    |
+| `translate`                         | bool  | Translate the text to English when set to True. Default: False                                                                                           |
+| `language`                          | str   | Language spoken in the audio, specify None to perform language detection. Default: None                                                                  |
+| `temperature`                       | float | Temperature to use for sampling. Default: 0                                                                                                              |
+| `best_of`                           | int   | Number of candidates when sampling with non-zero temperature. Default: 5                                                                                 |
+| `beam_size`                         | int   | Number of beams in beam search, only applicable when temperature is zero. Default: 5                                                                     |
+| `patience`                          | float | Optional patience value to use in beam decoding. Default: None                                                                                           |
+| `length_penalty`                    | float | Optional token length penalty coefficient (alpha). Default: None                                                                                         |
+| `suppress_tokens`                   | str   | Comma-separated list of token ids to suppress during sampling. Default: "-1"                                                                             |
+| `initial_prompt`                    | str   | Optional text to provide as a prompt for the first window. Default: None                                                                                 |
+| `condition_on_previous_text`        | bool  | If True, provide the previous output of the model as a prompt for the next window. Default: True                                                         |
+| `temperature_increment_on_fallback` | float | Temperature to increase when falling back when the decoding fails. Default: 0.2                                                                          |
+| `compression_ratio_threshold`       | float | If the gzip compression ratio is higher than this value, treat the decoding as failed. Default: 2.4                                                      |
+| `logprob_threshold`                 | float | If the average log probability is lower than this value, treat the decoding as failed. Default: -1.0                                                     |
+| `no_speech_threshold`               | float | If the probability of the token is higher than this value, consider the segment as silence. Default: 0.6                                                 |
+| `enable_vad`                        | bool  | If True, use the voice activity detection (VAD) to filter out parts of the audio without speech. This step is using the Silero VAD model. Default: False |
 
 ## Test Inputs
 
@@ -43,3 +45,35 @@ The following inputs can be used for testing the model:
     }
 }
 ```
+
+## Sample output
+```json
+{
+    "segments": [
+        {
+            "id": 1,
+            "seek": 106,
+            "start": 0.11,
+            "end": 3.11,
+            "text": " Hola mundo.",
+            "tokens": [
+                50364,
+                22637,
+                7968,
+                13,
+                50514
+            ],
+            "temperature": 0.1,
+            "avg_logprob": -0.8348079785480325,
+            "compression_ratio": 0.5789473684210527,
+            "no_speech_prob": 0.1453857421875
+        }
+    ],
+    "detected_language": "es",
+    "transcription": "Hola mundo.",
+    "translation": null,
+    "device": "cuda",
+    "model": "large-v2",
+    "translation_time": 0.7796223163604736
+}
+````

--- a/README.md
+++ b/README.md
@@ -76,4 +76,4 @@ The following inputs can be used for testing the model:
     "model": "large-v2",
     "translation_time": 0.7796223163604736
 }
-````
+```

--- a/locustfile.py
+++ b/locustfile.py
@@ -1,0 +1,49 @@
+import io
+
+import numpy as np
+from locust import HttpUser, task
+import base64
+from pydub import AudioSegment
+
+
+def generate_random_audio(duration_ms):
+    # Generate random data
+    samples = np.random.normal(0, 1, int(44100 * duration_ms / 1000.0))
+
+    # Convert to int16 array so we can make use of the pydub package
+    samples = (samples * np.iinfo(np.int16).max).astype(np.int16)
+
+    # Create an audio segment
+    audio_segment = AudioSegment(
+        samples.tobytes(),
+        frame_rate=44100,
+        sample_width=samples.dtype.itemsize,
+        channels=1
+    )
+
+    # Convert the audio segment to a base64 string
+    buffer = io.BytesIO()
+    audio_segment.export(buffer, format="wav")
+    base64_audio = base64.b64encode(buffer.getvalue()).decode('utf-8')
+
+    return base64_audio
+
+class ApiUser(HttpUser):
+    @task
+    def send_audio_request(self):
+        headers = {
+            'Content-Type': 'application/json',
+        }
+        audio_data = generate_random_audio(1000)    # 1 second audio
+        
+        data = {
+            "input": {
+                "audio": audio_data
+            }
+        }
+        
+        self.client.post("/v2/xxxxx/runsync", json=data, headers=headers)  # Replace with your endpoint ID
+
+if __name__ == "__main__":
+    import os
+    os.system("locust -f this_file_name.py")

--- a/src/predict.py
+++ b/src/predict.py
@@ -17,7 +17,7 @@ from faster_whisper.utils import format_timestamp
 
 
 class Predictor:
-    ''' A Predictor class for the Whisper model '''
+    """ A Predictor class for the Whisper model """
 
     def setup(self):
         """Load the model into memory to make running multiple predictions efficient"""
@@ -60,6 +60,7 @@ class Predictor:
         compression_ratio_threshold=2.4,
         logprob_threshold=-1.0,
         no_speech_threshold=0.6,
+        enable_vad=False,
     ):
         """
         Run a single prediction on the model
@@ -91,26 +92,27 @@ class Predictor:
                                                suppress_tokens=[-1],
                                                without_timestamps=False,
                                                max_initial_timestamp=1.0,
-                                               word_timestamps=False
+                                               word_timestamps=False,
+                                               vad_filter=enable_vad
                                                ))
 
         segments = list(segments)
 
         if transcription == "plain_text":
+            transcription = "".join([segment.text.lstrip() for segment in segments])
+        elif transcription == "formatted_text":
             transcription = "\n".join([segment.text.lstrip() for segment in segments])
-        # elif transcription == "srt":
-        #     transcription = write_srt(result["segments"])
-        # else:
-        #     transcription = write_vtt(result["segments"])
-
         elif transcription == "srt":
             transcription = write_srt(segments)
         else:
             transcription = write_vtt(segments)
 
         if translate:
-            translation_segments, translation_info = model.transcribe(str(audio), task="translate", temperature=temperature
-                                                                      )
+            translation_segments, translation_info = model.transcribe(
+                str(audio),
+                task="translate",
+                temperature=temperature
+            )
 
         return {
             "segments": format_segments(segments),

--- a/src/predict.py
+++ b/src/predict.py
@@ -99,7 +99,7 @@ class Predictor:
         segments = list(segments)
 
         if transcription == "plain_text":
-            transcription = "".join([segment.text.lstrip() for segment in segments])
+            transcription = " ".join([segment.text.lstrip() for segment in segments])
         elif transcription == "formatted_text":
             transcription = "\n".join([segment.text.lstrip() for segment in segments])
         elif transcription == "srt":

--- a/src/rp_handler.py
+++ b/src/rp_handler.py
@@ -88,6 +88,7 @@ def run_whisper_job(job):
             compression_ratio_threshold=job_input["compression_ratio_threshold"],
             logprob_threshold=job_input["logprob_threshold"],
             no_speech_threshold=job_input["no_speech_threshold"],
+            enable_vad=job_input["enable_vad"]
         )
 
     with rp_debugger.LineTimer('cleanup_step'):

--- a/src/rp_schema.py
+++ b/src/rp_schema.py
@@ -88,5 +88,10 @@ INPUT_VALIDATIONS = {
         'type': float,
         'required': False,
         'default': 0.6
+    },
+    'enable_vad': {
+        'type': bool,
+        'required': False,
+        'default': False
     }
 }


### PR DESCRIPTION
## Main changes
* After #15 we should update the README to include the new inputs, added sample output too.
* Modify the default format `plain_text` to not include `\n`, just like OpenAI whisper API does. If you want each segment to use a different line you can use the new `formatted_text` format.
* Add option to enable VAD (voice activity detection) to filter parts of the audio without speech and improve speed/accuracy, by default it is disabled. #1 
* Added a locust file I used to generate random-length audios and test performance of the different GPUs available over Runpod, don't know where to place it or if it even belongs here, you can remove it if unsure :) 
## Tests
* Tested enabling and disabling vad filter:
![image](https://github.com/runpod-workers/worker-faster_whisper/assets/12993089/4b0ee5df-3464-4c6b-a19b-76c147eae9cf)
* `formatted_text` output:
![image](https://github.com/runpod-workers/worker-faster_whisper/assets/12993089/223bc2b7-aace-4e61-9f24-c038a232aee4)
* `plain_text` output:
![image](https://github.com/runpod-workers/worker-faster_whisper/assets/12993089/dff11cbf-c0f7-428f-b95f-68c957b1de2c)
