### PR TITLE
fix: VTT transcription hours place inclusion

### DIFF
--- a/src/predict.py
+++ b/src/predict.py
@@ -14,17 +14,18 @@ from faster_whisper.utils import format_timestamp
 
 
 class Predictor:
-    """ A Predictor class for the Whisper model """
+    """A Predictor class for the Whisper model"""
 
     def __init__(self):
         self.models = {}
 
     def load_model(self, model_name):
-        """ Load the model from the weights folder. """
+        """Load the model from the weights folder."""
         loaded_model = WhisperModel(
             model_name,
             device="cuda" if rp_cuda.is_available() else "cpu",
-            compute_type="float16" if rp_cuda.is_available() else "int8")
+            compute_type="float16" if rp_cuda.is_available() else "int8",
+        )
 
         return model_name, loaded_model
 
@@ -56,7 +57,7 @@ class Predictor:
         logprob_threshold=-1.0,
         no_speech_threshold=0.6,
         enable_vad=False,
-        word_timestamps=False
+        word_timestamps=False,
     ):
         """
         Run a single prediction on the model
@@ -72,27 +73,30 @@ class Predictor:
         else:
             temperature = [temperature]
 
-        segments, info = list(model.transcribe(str(audio),
-                                               language=language,
-                                               task="transcribe",
-                                               beam_size=beam_size,
-                                               best_of=best_of,
-                                               patience=patience,
-                                               length_penalty=length_penalty,
-                                               temperature=temperature,
-                                               compression_ratio_threshold=compression_ratio_threshold,
-                                               log_prob_threshold=logprob_threshold,
-                                               no_speech_threshold=no_speech_threshold,
-                                               condition_on_previous_text=condition_on_previous_text,
-                                               initial_prompt=initial_prompt,
-                                               prefix=None,
-                                               suppress_blank=True,
-                                               suppress_tokens=[-1],
-                                               without_timestamps=False,
-                                               max_initial_timestamp=1.0,
-                                               word_timestamps=word_timestamps,
-                                               vad_filter=enable_vad
-                                               ))
+        segments, info = list(
+            model.transcribe(
+                str(audio),
+                language=language,
+                task="transcribe",
+                beam_size=beam_size,
+                best_of=best_of,
+                patience=patience,
+                length_penalty=length_penalty,
+                temperature=temperature,
+                compression_ratio_threshold=compression_ratio_threshold,
+                log_prob_threshold=logprob_threshold,
+                no_speech_threshold=no_speech_threshold,
+                condition_on_previous_text=condition_on_previous_text,
+                initial_prompt=initial_prompt,
+                prefix=None,
+                suppress_blank=True,
+                suppress_tokens=[-1],
+                without_timestamps=False,
+                max_initial_timestamp=1.0,
+                word_timestamps=word_timestamps,
+                vad_filter=enable_vad,
+            )
+        )
 
         segments = list(segments)
 
@@ -107,9 +111,7 @@ class Predictor:
 
         if translate:
             translation_segments, translation_info = model.transcribe(
-                str(audio),
-                task="translate",
-                temperature=temperature
+                str(audio), task="translate", temperature=temperature
             )
 
         results = {
@@ -125,43 +127,47 @@ class Predictor:
             word_timestamps = []
             for segment in segments:
                 for word in segment.words:
-                    word_timestamps.append({
-                        "word": word.word,
-                        "start": word.start,
-                        "end": word.end,
-                    })
+                    word_timestamps.append(
+                        {
+                            "word": word.word,
+                            "start": word.start,
+                            "end": word.end,
+                        }
+                    )
             results["word_timestamps"] = word_timestamps
-
 
         return results
 
 
 def format_segments(transcript):
-    '''
+    """
     Format the segments to be returned in the API response.
-    '''
-    return [{
-        "id": segment.id,
-        "seek": segment.seek,
-        "start": segment.start,
-        "end": segment.end,
-        "text": segment.text,
-        "tokens": segment.tokens,
-        "temperature": segment.temperature,
-        "avg_logprob": segment.avg_logprob,
-        "compression_ratio": segment.compression_ratio,
-        "no_speech_prob": segment.no_speech_prob
-    } for segment in transcript]
+    """
+    return [
+        {
+            "id": segment.id,
+            "seek": segment.seek,
+            "start": segment.start,
+            "end": segment.end,
+            "text": segment.text,
+            "tokens": segment.tokens,
+            "temperature": segment.temperature,
+            "avg_logprob": segment.avg_logprob,
+            "compression_ratio": segment.compression_ratio,
+            "no_speech_prob": segment.no_speech_prob,
+        }
+        for segment in transcript
+    ]
 
 
 def write_vtt(transcript):
-    '''
+    """
     Write the transcript in VTT format.
-    '''
+    """
     result = ""
 
     for segment in transcript:
-        result += f"{format_timestamp(segment.start, always_include_hours=True)} --> {format_timestamp(segment.end)}\n"
+        result += f"{format_timestamp(segment.start, always_include_hours=True)} --> {format_timestamp(segment.end, always_include_hours=True)}\n"
         result += f"{segment.text.strip().replace('-->', '->')}\n"
         result += "\n"
 
@@ -169,9 +175,9 @@ def write_vtt(transcript):
 
 
 def write_srt(transcript):
-    '''
+    """
     Write the transcript in SRT format.
-    '''
+    """
     result = ""
 
     for i, segment in enumerate(transcript, start=1):

--- a/src/predict.py
+++ b/src/predict.py
@@ -161,7 +161,7 @@ def write_vtt(transcript):
     result = ""
 
     for segment in transcript:
-        result += f"{format_timestamp(segment.start)} --> {format_timestamp(segment.end)}\n"
+        result += f"{format_timestamp(segment.start, always_include_hours=True)} --> {format_timestamp(segment.end)}\n"
         result += f"{segment.text.strip().replace('-->', '->')}\n"
         result += "\n"
 


### PR DESCRIPTION
Makes VTT transcriptions timestamps always include the number of hours into the audio clip at which the current segment is spoken. Submitted as per a user's request/notice of the inconsistency.