### PR TITLE
upgrading faster-whisper and add large-v3 model

### DIFF
--- a/builder/fetch_models.py
+++ b/builder/fetch_models.py
@@ -1,7 +1,7 @@
 from concurrent.futures import ThreadPoolExecutor
 from faster_whisper import WhisperModel
 
-model_names = ["tiny", "base", "small", "medium", "large-v1", "large-v2"]
+model_names = ["tiny", "base", "small", "medium", "large-v1", "large-v2", "large-v3"]
 
 
 def load_model(selected_model):

--- a/builder/requirements.txt
+++ b/builder/requirements.txt
@@ -1,3 +1,3 @@
 runpod==1.4.2
 
-faster-whisper==0.9.0
+faster-whisper==0.10.0

--- a/src/predict.py
+++ b/src/predict.py
@@ -30,7 +30,7 @@ class Predictor:
 
     def setup(self):
         """Load the model into memory to make running multiple predictions efficient"""
-        model_names = ["tiny", "base", "small", "medium", "large-v1", "large-v2"]
+        model_names = ["tiny", "base", "small", "medium", "large-v1", "large-v2", "large-v3"]
         with ThreadPoolExecutor() as executor:
             for model_name, model in executor.map(self.load_model, model_names):
                 if model_name is not None:


### PR DESCRIPTION
This resolves #25 by adding `large-v3` into the initial model fetching code. I was testing using GitHub Actions with built-in workers on my main branch, but the built-in `ubuntu-latest` workers do not have enough disk space to put all large models into a single image for building. It would be good if the reviewers can help validate that. It would be good to use the warm worker for lower latency on Runpod compared to custom templates and endpoints.

On my main branch, I was able to build out a package and push to ghcr for using it in Runpod (after taking out `large-v1` and `large-v2` for building in GitHub Actions built-in runners).

Cheers!