### PR TITLE
add output formatting for translation jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,10 @@ This repository contains the [Faster Whisper](https://github.com/guillaumekln/fa
 |-------------------------------------|-------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `audio`                             | Path  | Audio file                                                                                                                                               |
 | `audio_base64`                      | str   | Base64-encoded audio file                                                                                                                                |
-| `model`                             | str   | Choose a Whisper model. Choices: "tiny", "base", "small", "medium", "large-v1", "large-v2", "large-v3". Default: "base"                                              |
+| `model`                             | str   | Choose a Whisper model. Choices: "tiny", "base", "small", "medium", "large-v1", "large-v2", "large-v3". Default: "base"                                  |
 | `transcription`                     | str   | Choose the format for the transcription. Choices: "plain_text", "formatted_text", "srt", "vtt". Default: "plain_text"                                    |
 | `translate`                         | bool  | Translate the text to English when set to True. Default: False                                                                                           |
+| `translation`                       | str   | Choose the format for the translation. Choices: "plain_text", "formatted_text", "srt", "vtt". Default: "plain_text"                                      |
 | `language`                          | str   | Language spoken in the audio, specify None to perform language detection. Default: None                                                                  |
 | `temperature`                       | float | Temperature to use for sampling. Default: 0                                                                                                              |
 | `best_of`                           | int   | Number of candidates when sampling with non-zero temperature. Default: 5                                                                                 |

--- a/locustfile.py
+++ b/locustfile.py
@@ -46,4 +46,4 @@ class ApiUser(HttpUser):
 
 if __name__ == "__main__":
     import os
-    os.system("locust -f this_file_name.py")
+    os.system("locust -f locustfile.py")

--- a/src/rp_handler.py
+++ b/src/rp_handler.py
@@ -73,6 +73,7 @@ def run_whisper_job(job):
             audio=audio_input,
             model_name=job_input["model"],
             transcription=job_input["transcription"],
+            translation=job_input["translation"],
             translate=job_input["translate"],
             language=job_input["language"],
             temperature=job_input["temperature"],

--- a/src/rp_schema.py
+++ b/src/rp_schema.py
@@ -24,6 +24,11 @@ INPUT_VALIDATIONS = {
         'required': False,
         'default': False
     },
+    'translation': {
+        'type': str,
+        'required': False,
+        'default': 'plain_text'
+    },
     'language': {
         'type': str,
         'required': False,


### PR DESCRIPTION
Currently, when the user requests translation they're forced to receive their translation in the `srt` format. For users consuming their Runpod worker and changing which key they respond with based on if a translation was ran, it is currently impossible to respond with easily human readable translations without implementing an `srt` parser. 

To fix this I've added a new input, `translation`. Which allows the user to pass any of the same options they would to `transcription`. 

I've also renamed the existing `format_segments` function to `serialize_segments`, as that's a more accurate name, and introduced my own `format_segments` in it's place.