### PR TITLE
Add Support for Distilled Whisper Models and Update Dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository contains the [Faster Whisper](https://github.com/guillaumekln/fa
 |-------------------------------------|-------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `audio`                             | Path  | Audio file                                                                                                                                               |
 | `audio_base64`                      | str   | Base64-encoded audio file                                                                                                                                |
-| `model`                             | str   | Choose a Whisper model. Choices: "tiny", "base", "small", "medium", "large-v1", "large-v2", "large-v3". Default: "base"                                  |
+| `model`                             | str   | Choose a Whisper model. Choices: "tiny", "base", "small", "medium", "large-v1", "large-v2", "large-v3", "distil-large-v2", "distil-large-v3". Default: "base"                                  |
 | `transcription`                     | str   | Choose the format for the transcription. Choices: "plain_text", "formatted_text", "srt", "vtt". Default: "plain_text"                                    |
 | `translate`                         | bool  | Translate the text to English when set to True. Default: False                                                                                           |
 | `translation`                       | str   | Choose the format for the translation. Choices: "plain_text", "formatted_text", "srt", "vtt". Default: "plain_text"                                      |

--- a/builder/fetch_models.py
+++ b/builder/fetch_models.py
@@ -1,7 +1,7 @@
 from concurrent.futures import ThreadPoolExecutor
 from faster_whisper import WhisperModel
 
-model_names = ["tiny", "base", "small", "medium", "large-v1", "large-v2", "large-v3"]
+model_names = ["tiny", "base", "small", "medium", "large-v1", "large-v2", "large-v3", "distil-large-v2", "distil-large-v3"]
 
 
 def load_model(selected_model):

--- a/builder/requirements.txt
+++ b/builder/requirements.txt
@@ -1,3 +1,3 @@
 runpod~=1.7.0
 
-faster-whisper==0.10.0
+faster-whisper==1.0.3


### PR DESCRIPTION
This PR enhances the functionality and usability of the repository by:

1. **Adding Support for Distilled Whisper Models**:
   - Expanded `model` options to include "distil-large-v2" and "distil-large-v3" models in both the README and `fetch_models.py` to allow users to leverage these more lightweight versions.

2. **Updating Dependency Versions**:
   - Upgraded `faster-whisper` dependency in `requirements.txt` from version `0.10.0` to `1.0.3`, ensuring compatibility with the new models and taking advantage of recent improvements.

These changes will allow users greater flexibility in selecting models that best fit their needs for speed and performance.