### PR TITLE
feat: add "turbo" and disable auto-loading of all models into vram

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,14 @@
-<div align="center">
+<h1>Faster Whisper</h1>
 
-<h1>Faster Whisper | Worker</h1>
+[Faster Whisper](https://github.com/guillaumekln/faster-whisper) is designed to process audio files using various Whisper models, with options for transcription formatting, language translation and more.
 
-This repository contains the [Faster Whisper](https://github.com/guillaumekln/faster-whisper) Worker for RunPod. The Whisper Worker is designed to process audio files using various Whisper models, with options for transcription formatting, language translation, and more. It's part of the RunPod Workers collection aimed at providing diverse functionality for endpoint processing.
-
-[Endpoint Docs](https://docs.runpod.io/reference/faster-whisper)
-
-[Docker Image](https://hub.docker.com/r/runpod/ai-api-faster-whisper)
-
-</div>
-
-## Model Inputs
+## Input
 
 | Input                               | Type  | Description                                                                                                                                              |
-|-------------------------------------|-------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `audio`                             | Path  | Audio file                                                                                                                                               |
+| ----------------------------------- | ----- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `audio`                             | Path  | URL to Audio file                                                                                                                                        |
 | `audio_base64`                      | str   | Base64-encoded audio file                                                                                                                                |
-| `model`                             | str   | Choose a Whisper model. Choices: "tiny", "base", "small", "medium", "large-v1", "large-v2", "large-v3", "turbo". Default: "base"                                  |
+| `model`                             | str   | Choose a Whisper model. Choices: "tiny", "base", "small", "medium", "large-v1", "large-v2", "large-v3", "turbo". Default: "base"                         |
 | `transcription`                     | str   | Choose the format for the transcription. Choices: "plain_text", "formatted_text", "srt", "vtt". Default: "plain_text"                                    |
 | `translate`                         | bool  | Translate the text to English when set to True. Default: False                                                                                           |
 | `translation`                       | str   | Choose the format for the translation. Choices: "plain_text", "formatted_text", "srt", "vtt". Default: "plain_text"                                      |
@@ -36,46 +28,41 @@ This repository contains the [Faster Whisper](https://github.com/guillaumekln/fa
 | `enable_vad`                        | bool  | If True, use the voice activity detection (VAD) to filter out parts of the audio without speech. This step is using the Silero VAD model. Default: False |
 | `word_timestamps`                   | bool  | If True, include word timestamps in the output. Default: False                                                                                           |
 
-## Test Inputs
+### Example
 
 The following inputs can be used for testing the model:
 
 ```json
 {
-    "input": {
-        "audio": "https://github.com/runpod-workers/sample-inputs/raw/main/audio/gettysburg.wav"
-    }
+  "input": {
+    "audio": "https://github.com/runpod-workers/sample-inputs/raw/main/audio/gettysburg.wav"
+  }
 }
 ```
 
-## Sample output
+producing an output like this:
+
 ```json
 {
-    "segments": [
-        {
-            "id": 1,
-            "seek": 106,
-            "start": 0.11,
-            "end": 3.11,
-            "text": " Hola mundo.",
-            "tokens": [
-                50364,
-                22637,
-                7968,
-                13,
-                50514
-            ],
-            "temperature": 0.1,
-            "avg_logprob": -0.8348079785480325,
-            "compression_ratio": 0.5789473684210527,
-            "no_speech_prob": 0.1453857421875
-        }
-    ],
-    "detected_language": "es",
-    "transcription": "Hola mundo.",
-    "translation": null,
-    "device": "cuda",
-    "model": "large-v2",
-    "translation_time": 0.7796223163604736
+  "segments": [
+    {
+      "id": 1,
+      "seek": 106,
+      "start": 0.11,
+      "end": 3.11,
+      "text": " Hello and welcome!",
+      "tokens": [50364, 25, 7, 287, 50514],
+      "temperature": 0.1,
+      "avg_logprob": -0.8348079785480325,
+      "compression_ratio": 0.5789473684210527,
+      "no_speech_prob": 0.1453857421875
+    }
+  ],
+  "detected_language": "en",
+  "transcription": "Hello and welcome!",
+  "translation": null,
+  "device": "cuda",
+  "model": "turbo",
+  "translation_time": 0.3796223163604736
 }
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This repository contains the [Faster Whisper](https://github.com/guillaumekln/fa
 |-------------------------------------|-------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `audio`                             | Path  | Audio file                                                                                                                                               |
 | `audio_base64`                      | str   | Base64-encoded audio file                                                                                                                                |
-| `model`                             | str   | Choose a Whisper model. Choices: "tiny", "base", "small", "medium", "large-v1", "large-v2", "large-v3". Default: "base"                                  |
+| `model`                             | str   | Choose a Whisper model. Choices: "tiny", "base", "small", "medium", "large-v1", "large-v2", "large-v3", "turbo". Default: "base"                                  |
 | `transcription`                     | str   | Choose the format for the transcription. Choices: "plain_text", "formatted_text", "srt", "vtt". Default: "plain_text"                                    |
 | `translate`                         | bool  | Translate the text to English when set to True. Default: False                                                                                           |
 | `translation`                       | str   | Choose the format for the translation. Choices: "plain_text", "formatted_text", "srt", "vtt". Default: "plain_text"                                      |

--- a/builder/fetch_models.py
+++ b/builder/fetch_models.py
@@ -1,29 +1,28 @@
-from concurrent.futures import ThreadPoolExecutor
-from faster_whisper import WhisperModel
+from faster_whisper.utils import download_model
 
-model_names = ["tiny", "base", "small", "medium", "large-v1", "large-v2", "large-v3", "turbo"]
-
-
-def load_model(selected_model):
-    '''
-    Load and cache models in parallel
-    '''
-    for _attempt in range(5):
-        while True:
-            try:
-                loaded_model = WhisperModel(
-                    selected_model, device="cpu", compute_type="int8")
-            except (AttributeError, OSError):
-                continue
-
-            break
-
-    return selected_model, loaded_model
+model_names = [
+    "tiny",
+    "base",
+    "small",
+    "medium",
+    "large-v1",
+    "large-v2",
+    "large-v3",
+    "turbo",
+]
 
 
-models = {}
+def download_model_weights(selected_model):
+    """
+    Download model weights.
+    """
+    print(f"Downloading {selected_model}...")
+    download_model(selected_model, cache_dir=None)
+    print(f"Finished downloading {selected_model}.")
 
-with ThreadPoolExecutor() as executor:
-    for model_name, model in executor.map(load_model, model_names):
-        if model_name is not None:
-            models[model_name] = model
+
+# Loop through models sequentially
+for model_name in model_names:
+    download_model_weights(model_name)
+
+print("Finished downloading all models.")

--- a/builder/fetch_models.py
+++ b/builder/fetch_models.py
@@ -1,7 +1,7 @@
 from concurrent.futures import ThreadPoolExecutor
 from faster_whisper import WhisperModel
 
-model_names = ["tiny", "base", "small", "medium", "large-v1", "large-v2", "large-v3"]
+model_names = ["tiny", "base", "small", "medium", "large-v1", "large-v2", "large-v3", "turbo"]
 
 
 def load_model(selected_model):

--- a/builder/requirements.txt
+++ b/builder/requirements.txt
@@ -1,3 +1,3 @@
 runpod~=1.7.0
 
-faster-whisper==0.10.0
+faster-whisper==1.1.0

--- a/src/predict.py
+++ b/src/predict.py
@@ -4,7 +4,11 @@ Whisper model. It is based on the Predictor class from the original Whisper
 repository, with some modifications to make it work with the RP platform.
 """
 
-from concurrent.futures import ThreadPoolExecutor
+import gc
+import threading
+from concurrent.futures import (
+    ThreadPoolExecutor,
+)  # Still needed for transcribe potentially?
 import numpy as np
 
 from runpod.serverless.utils import rp_cuda
@@ -12,29 +16,34 @@ from runpod.serverless.utils import rp_cuda
 from faster_whisper import WhisperModel
 from faster_whisper.utils import format_timestamp
 
+# Define available models (for validation)
+AVAILABLE_MODELS = {
+    "tiny",
+    "base",
+    "small",
+    "medium",
+    "large-v1",
+    "large-v2",
+    "large-v3",
+    "turbo",
+}
+
 
 class Predictor:
-    """ A Predictor class for the Whisper model """
+    """A Predictor class for the Whisper model with lazy loading"""
 
     def __init__(self):
+        """Initializes the predictor with no models loaded."""
         self.models = {}
+        self.model_lock = (
+            threading.Lock()
+        )  # Lock for thread-safe model loading/unloading
 
-    def load_model(self, model_name):
-        """ Load the model from the weights folder. """
-        loaded_model = WhisperModel(
-            model_name,
-            device="cuda" if rp_cuda.is_available() else "cpu",
-            compute_type="float16" if rp_cuda.is_available() else "int8")
-
-        return model_name, loaded_model
+    # Removed load_model method
 
     def setup(self):
-        """Load the model into memory to make running multiple predictions efficient"""
-        model_names = ["tiny", "base", "small", "medium", "large-v1", "large-v2", "large-v3","turbo"]
-        with ThreadPoolExecutor() as executor:
-            for model_name, model in executor.map(self.load_model, model_names):
-                if model_name is not None:
-                    self.models[model_name] = model
+        """No models are pre-loaded. Setup is minimal."""
+        pass
 
     def predict(
         self,
@@ -42,7 +51,7 @@ class Predictor:
         model_name="base",
         transcription="plain_text",
         translate=False,
-        translation="plain_text",
+        translation="plain_text",  # Added in a previous PR
         language=None,
         temperature=0,
         best_of=5,
@@ -57,14 +66,63 @@ class Predictor:
         logprob_threshold=-1.0,
         no_speech_threshold=0.6,
         enable_vad=False,
-        word_timestamps=False
+        word_timestamps=False,
     ):
         """
-        Run a single prediction on the model
+        Run a single prediction on the model, loading/unloading models as needed.
         """
-        model = self.models.get(model_name)
-        if not model:
-            raise ValueError(f"Model '{model_name}' not found.")
+        if model_name not in AVAILABLE_MODELS:
+            raise ValueError(
+                f"Invalid model name: {model_name}. Available models are: {AVAILABLE_MODELS}"
+            )
+
+        with self.model_lock:
+            model = None
+            if model_name not in self.models:
+                # Unload existing model if necessary
+                if self.models:
+                    existing_model_name = list(self.models.keys())[0]
+                    print(f"Unloading model: {existing_model_name}...")
+                    # Remove reference and clear dict
+                    del self.models[existing_model_name]
+                    self.models.clear()
+                    # Hint Python to release memory
+                    gc.collect()
+                    if rp_cuda.is_available():
+                        # If using PyTorch models, you might call torch.cuda.empty_cache()
+                        # FasterWhisper uses CTranslate2; explicit cache clearing might not be needed
+                        # but gc.collect() is generally helpful.
+                        pass
+                    print(f"Model {existing_model_name} unloaded.")
+
+                # Load the requested model
+                print(f"Loading model: {model_name}...")
+                try:
+                    loaded_model = WhisperModel(
+                        model_name,
+                        device="cuda" if rp_cuda.is_available() else "cpu",
+                        compute_type="float16" if rp_cuda.is_available() else "int8",
+                    )
+                    self.models[model_name] = loaded_model
+                    model = loaded_model
+                    print(f"Model {model_name} loaded successfully.")
+                except Exception as e:
+                    print(f"Error loading model {model_name}: {e}")
+                    raise ValueError(f"Failed to load model {model_name}: {e}") from e
+            else:
+                # Model already loaded
+                model = self.models[model_name]
+                print(f"Using already loaded model: {model_name}")
+
+            # Ensure model is loaded before proceeding
+            if model is None:
+                raise RuntimeError(
+                    f"Model {model_name} could not be loaded or retrieved."
+                )
+
+        # Model is now loaded and ready, proceed with prediction (outside the lock?)
+        # Consider if transcribe is thread-safe or if it should also be within the lock
+        # For now, keeping transcribe outside as it's CPU/GPU bound work
 
         if temperature_increment_on_fallback is not None:
             temperature = tuple(
@@ -73,106 +131,124 @@ class Predictor:
         else:
             temperature = [temperature]
 
-        segments, info = list(model.transcribe(str(audio),
-                                               language=language,
-                                               task="transcribe",
-                                               beam_size=beam_size,
-                                               best_of=best_of,
-                                               patience=patience,
-                                               length_penalty=length_penalty,
-                                               temperature=temperature,
-                                               compression_ratio_threshold=compression_ratio_threshold,
-                                               log_prob_threshold=logprob_threshold,
-                                               no_speech_threshold=no_speech_threshold,
-                                               condition_on_previous_text=condition_on_previous_text,
-                                               initial_prompt=initial_prompt,
-                                               prefix=None,
-                                               suppress_blank=True,
-                                               suppress_tokens=[-1],
-                                               without_timestamps=False,
-                                               max_initial_timestamp=1.0,
-                                               word_timestamps=word_timestamps,
-                                               vad_filter=enable_vad
-                                               ))
+        # Note: FasterWhisper's transcribe might release the GIL, potentially allowing
+        # other threads to acquire the model_lock if transcribe is lengthy.
+        # If issues arise, the lock might need to encompass the transcribe call too.
+        segments, info = list(
+            model.transcribe(
+                str(audio),
+                language=language,
+                task="transcribe",
+                beam_size=beam_size,
+                best_of=best_of,
+                patience=patience,
+                length_penalty=length_penalty,
+                temperature=temperature,
+                compression_ratio_threshold=compression_ratio_threshold,
+                log_prob_threshold=logprob_threshold,
+                no_speech_threshold=no_speech_threshold,
+                condition_on_previous_text=condition_on_previous_text,
+                initial_prompt=initial_prompt,
+                prefix=None,
+                suppress_blank=True,
+                suppress_tokens=[-1],  # Might need conversion from string
+                without_timestamps=False,
+                max_initial_timestamp=1.0,
+                word_timestamps=word_timestamps,
+                vad_filter=enable_vad,
+            )
+        )
 
         segments = list(segments)
 
-        transcription = format_segments(transcription, segments)
+        # Format transcription
+        transcription_output = format_segments(transcription, segments)
 
+        # Handle translation if requested
+        translation_output = None
         if translate:
-            translation_segments, translation_info = model.transcribe(
+            translation_segments, _ = model.transcribe(
                 str(audio),
                 task="translate",
-                temperature=temperature
+                temperature=temperature,  # Reuse temperature settings for translation
             )
-
-            translation = format_segments(translation, translation_segments)
+            translation_output = format_segments(
+                translation, list(translation_segments)
+            )
 
         results = {
             "segments": serialize_segments(segments),
             "detected_language": info.language,
-            "transcription": transcription,
-            "translation": translation if translate else None,
+            "transcription": transcription_output,
+            "translation": translation_output,
             "device": "cuda" if rp_cuda.is_available() else "cpu",
             "model": model_name,
         }
 
         if word_timestamps:
-            word_timestamps = []
+            word_timestamps_list = []
             for segment in segments:
                 for word in segment.words:
-                    word_timestamps.append({
-                        "word": word.word,
-                        "start": word.start,
-                        "end": word.end,
-                    })
-            results["word_timestamps"] = word_timestamps
-
+                    word_timestamps_list.append(
+                        {
+                            "word": word.word,
+                            "start": word.start,
+                            "end": word.end,
+                        }
+                    )
+            results["word_timestamps"] = word_timestamps_list
 
         return results
 
 
 def serialize_segments(transcript):
-    '''
+    """
     Serialize the segments to be returned in the API response.
-    '''
-    return [{
-        "id": segment.id,
-        "seek": segment.seek,
-        "start": segment.start,
-        "end": segment.end,
-        "text": segment.text,
-        "tokens": segment.tokens,
-        "temperature": segment.temperature,
-        "avg_logprob": segment.avg_logprob,
-        "compression_ratio": segment.compression_ratio,
-        "no_speech_prob": segment.no_speech_prob
-    } for segment in transcript]
+    """
+    return [
+        {
+            "id": segment.id,
+            "seek": segment.seek,
+            "start": segment.start,
+            "end": segment.end,
+            "text": segment.text,
+            "tokens": segment.tokens,
+            "temperature": segment.temperature,
+            "avg_logprob": segment.avg_logprob,
+            "compression_ratio": segment.compression_ratio,
+            "no_speech_prob": segment.no_speech_prob,
+        }
+        for segment in transcript
+    ]
 
 
-def format_segments(format, segments):
-    '''
+def format_segments(format_type, segments):
+    """
     Format the segments to the desired format
-    '''
+    """
 
-    if format == "plain_text":
+    if format_type == "plain_text":
         return " ".join([segment.text.lstrip() for segment in segments])
-    elif format == "formatted_text":
+    elif format_type == "formatted_text":
         return "\n".join([segment.text.lstrip() for segment in segments])
-    elif format == "srt":
+    elif format_type == "srt":
         return write_srt(segments)
-    
-    return write_vtt(segments)
+    elif format_type == "vtt":  # Added VTT case
+        return write_vtt(segments)
+    else:  # Default or unknown format
+        print(f"Warning: Unknown format '{format_type}', defaulting to plain text.")
+        return " ".join([segment.text.lstrip() for segment in segments])
 
 
 def write_vtt(transcript):
-    '''
+    """
     Write the transcript in VTT format.
-    '''
+    """
     result = ""
 
     for segment in transcript:
-        result += f"{format_timestamp(segment.start)} --> {format_timestamp(segment.end)}\n"
+        # Using the consistent timestamp format from previous PR
+        result += f"{format_timestamp(segment.start, always_include_hours=True)} --> {format_timestamp(segment.end, always_include_hours=True)}\n"
         result += f"{segment.text.strip().replace('-->', '->')}\n"
         result += "\n"
 
@@ -180,9 +256,9 @@ def write_vtt(transcript):
 
 
 def write_srt(transcript):
-    '''
+    """
     Write the transcript in SRT format.
-    '''
+    """
     result = ""
 
     for i, segment in enumerate(transcript, start=1):

--- a/src/predict.py
+++ b/src/predict.py
@@ -30,7 +30,7 @@ class Predictor:
 
     def setup(self):
         """Load the model into memory to make running multiple predictions efficient"""
-        model_names = ["tiny", "base", "small", "medium", "large-v1", "large-v2", "large-v3"]
+        model_names = ["tiny", "base", "small", "medium", "large-v1", "large-v2", "large-v3","turbo"]
         with ThreadPoolExecutor() as executor:
             for model_name, model in executor.map(self.load_model, model_names):
                 if model_name is not None:

--- a/test_input.json
+++ b/test_input.json
@@ -1,0 +1,17 @@
+{
+  "input": {
+    "audio": "https://github.com/runpod-workers/sample-inputs/raw/main/audio/gettysburg.wav",
+    "model": "turbo",
+    "transcription": "plain text",
+    "translate": false,
+    "temperature": 0,
+    "best_of": 5,
+    "beam_size": 5,
+    "suppress_tokens": "-1",
+    "condition_on_previous_text": false,
+    "temperature_increment_on_fallback": 0.2,
+    "compression_ratio_threshold": 2.4,
+    "logprob_threshold": -1,
+    "no_speech_threshold": 0.6
+  }
+}


### PR DESCRIPTION
The faster-whisper package (version 1.1.0) now includes support for turbo. The changes here are:

1) Updated the package version in faster-whisper to 1.1.0 (from 0.1)
2) Updated the fetch_model file to include "turbo"
3) Updated the read_me file to include the model "turbo" in the description.

Note: I have not tested the full setup as is on here, but I have tested the package locally and have used very similar code in my local implementation.