### PR TITLE
Update image to the latest version of faster whisper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 # Use specific version of nvidia cuda image
-FROM nvidia/cuda:11.7.1-cudnn8-runtime-ubuntu20.04
-
-# Remove any third-party apt sources to avoid issues with expiring keys.
-RUN rm -f /etc/apt/sources.list.d/*.list
+FROM nvidia/cuda:12.6.3-cudnn-runtime-ubuntu24.04
 
 # Set shell and noninteractive environment variables
 SHELL ["/bin/bash", "-c"]
@@ -13,42 +10,40 @@ ENV SHELL=/bin/bash
 WORKDIR /
 
 # Update and upgrade the system packages (Worker Template)
-RUN apt-get update -y && \
-    apt-get upgrade -y && \
-    apt-get install --yes --no-install-recommends sudo ca-certificates git wget curl bash libgl1 libx11-6 software-properties-common ffmpeg build-essential -y &&\
-    apt-get autoremove -y && \
-    apt-get clean -y && \
+RUN apt update -y && \
+    apt upgrade -y && \
+    apt full-upgrade -y && \
+    apt install -y --yes --no-install-recommends sudo ca-certificates git wget curl bash libgl1 libx11-6 software-properties-common ffmpeg build-essential \
+    python3.12-dev python3.12-venv python3-pip \
+    libnvidia-compute-565-server \
+    libnvidia-encode-565-server \
+    libnvidia-decode-565-server \
+    libnvidia-extra-565-server \
+    libnvidia-gl-565-server \
+    libnvidia-encode-565-server \
+    libnvidia-decode-565-server \
+    libnvidia-common-565-server \
+    nvidia-utils-565-server \
+    && \
+    apt autoremove -y && \
+    apt clean -y && \
     rm -rf /var/lib/apt/lists/*
 
-# Add the deadsnakes PPA and install Python 3.10
-RUN add-apt-repository ppa:deadsnakes/ppa -y && \
-    apt-get install python3.10-dev python3.10-venv python3-pip -y --no-install-recommends && \
-    ln -s /usr/bin/python3.10 /usr/bin/python && \
-    rm /usr/bin/python3 && \
-    ln -s /usr/bin/python3.10 /usr/bin/python3 && \
-    apt-get autoremove -y && \
-    apt-get clean -y && \
-    rm -rf /var/lib/apt/lists/*
-
-# Download and install pip
-RUN curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-    python get-pip.py && \
-    rm get-pip.py
-
-# Install Python dependencies (Worker Template)
+# Create and activate virtual environment, then install Python dependencies (Worker Template)
 COPY builder/requirements.txt /requirements.txt
-RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install --upgrade pip && \
+RUN python3.12 -m venv /opt/venv && \
+    . /opt/venv/bin/activate && \
     pip install -r /requirements.txt --no-cache-dir && \
     rm /requirements.txt
 
 # Copy and run script to fetch models
 COPY builder/fetch_models.py /fetch_models.py
-RUN python /fetch_models.py && \
+RUN . /opt/venv/bin/activate && \
+    python /fetch_models.py && \
     rm /fetch_models.py
 
 # Copy source code into image
 COPY src .
 
 # Set default command
-CMD python -u /rp_handler.py
+CMD . /opt/venv/bin/activate && python /rp_handler.py

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<h1>Faster Whisper | Worker</h1>
+# Faster Whisper | Worker
 
 This repository contains the [Faster Whisper](https://github.com/guillaumekln/faster-whisper) Worker for RunPod. The Whisper Worker is designed to process audio files using various Whisper models, with options for transcription formatting, language translation, and more. It's part of the RunPod Workers collection aimed at providing diverse functionality for endpoint processing.
 
@@ -16,16 +16,17 @@ This repository contains the [Faster Whisper](https://github.com/guillaumekln/fa
 |-------------------------------------|-------|----------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `audio`                             | Path  | Audio file                                                                                                                                               |
 | `audio_base64`                      | str   | Base64-encoded audio file                                                                                                                                |
-| `model`                             | str   | Choose a Whisper model. Choices: "tiny", "base", "small", "medium", "large-v1", "large-v2", "large-v3". Default: "base"                                  |
+| `model`                             | str   | Choose a Whisper model. Choices: "distil-large-v3" "large-v3". Default: "large-v3"                              |
 | `transcription`                     | str   | Choose the format for the transcription. Choices: "plain_text", "formatted_text", "srt", "vtt". Default: "plain_text"                                    |
+| `multilingual`                      | bool  | Enable multilingual processing. Default: False                                                                                                           |
 | `translate`                         | bool  | Translate the text to English when set to True. Default: False                                                                                           |
 | `translation`                       | str   | Choose the format for the translation. Choices: "plain_text", "formatted_text", "srt", "vtt". Default: "plain_text"                                      |
 | `language`                          | str   | Language spoken in the audio, specify None to perform language detection. Default: None                                                                  |
 | `temperature`                       | float | Temperature to use for sampling. Default: 0                                                                                                              |
 | `best_of`                           | int   | Number of candidates when sampling with non-zero temperature. Default: 5                                                                                 |
 | `beam_size`                         | int   | Number of beams in beam search, only applicable when temperature is zero. Default: 5                                                                     |
-| `patience`                          | float | Optional patience value to use in beam decoding. Default: None                                                                                           |
-| `length_penalty`                    | float | Optional token length penalty coefficient (alpha). Default: None                                                                                         |
+| `patience`                          | float | Optional patience value to use in beam decoding. Default: 1.0                                                                                            |
+| `length_penalty`                    | float | Optional token length penalty coefficient (alpha). Default: 0.0                                                                                          |
 | `suppress_tokens`                   | str   | Comma-separated list of token ids to suppress during sampling. Default: "-1"                                                                             |
 | `initial_prompt`                    | str   | Optional text to provide as a prompt for the first window. Default: None                                                                                 |
 | `condition_on_previous_text`        | bool  | If True, provide the previous output of the model as a prompt for the next window. Default: True                                                         |
@@ -33,8 +34,9 @@ This repository contains the [Faster Whisper](https://github.com/guillaumekln/fa
 | `compression_ratio_threshold`       | float | If the gzip compression ratio is higher than this value, treat the decoding as failed. Default: 2.4                                                      |
 | `logprob_threshold`                 | float | If the average log probability is lower than this value, treat the decoding as failed. Default: -1.0                                                     |
 | `no_speech_threshold`               | float | If the probability of the token is higher than this value, consider the segment as silence. Default: 0.6                                                 |
-| `enable_vad`                        | bool  | If True, use the voice activity detection (VAD) to filter out parts of the audio without speech. This step is using the Silero VAD model. Default: False |
+| `enable_vad`                        | bool  | If True, use the voice activity detection (VAD) to filter out parts of the audio without speech. This step is using the Silero VAD model. Default: True  |
 | `word_timestamps`                   | bool  | If True, include word timestamps in the output. Default: False                                                                                           |
+| `batch_size`                        | int   | Batch size for processing. Default: 8                                                                                                                    |
 
 ## Test Inputs
 

--- a/builder/fetch_models.py
+++ b/builder/fetch_models.py
@@ -1,7 +1,7 @@
 from concurrent.futures import ThreadPoolExecutor
 from faster_whisper import WhisperModel
 
-model_names = ["tiny", "base", "small", "medium", "large-v1", "large-v2", "large-v3"]
+model_names = ["large-v3", "distil-large-v3"]
 
 
 def load_model(selected_model):

--- a/builder/requirements.txt
+++ b/builder/requirements.txt
@@ -1,3 +1,3 @@
 runpod~=1.7.0
 
-faster-whisper==0.10.0
+faster-whisper==1.1.1

--- a/src/rp_handler.py
+++ b/src/rp_handler.py
@@ -31,6 +31,7 @@ def base64_to_tempfile(base64_file: str) -> str:
     '''
     with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as temp_file:
         temp_file.write(base64.b64decode(base64_file))
+    print(f"Created tempfile: {temp_file.name}")
 
     return temp_file.name
 
@@ -63,7 +64,8 @@ def run_whisper_job(job):
 
     if job_input.get('audio', False):
         with rp_debugger.LineTimer('download_step'):
-            audio_input = download_files_from_urls(job['id'], [job_input['audio']])[0]
+            audio_input = download_files_from_urls(
+                job['id'], [job_input['audio']])[0]
 
     if job_input.get('audio_base64', False):
         audio_input = base64_to_tempfile(job_input['audio_base64'])
@@ -74,6 +76,7 @@ def run_whisper_job(job):
             model_name=job_input["model"],
             transcription=job_input["transcription"],
             translation=job_input["translation"],
+            multilingual=job_input["multilingual"],
             translate=job_input["translate"],
             language=job_input["language"],
             temperature=job_input["temperature"],
@@ -89,7 +92,8 @@ def run_whisper_job(job):
             logprob_threshold=job_input["logprob_threshold"],
             no_speech_threshold=job_input["no_speech_threshold"],
             enable_vad=job_input["enable_vad"],
-            word_timestamps=job_input["word_timestamps"]
+            word_timestamps=job_input["word_timestamps"],
+            batch_size=job_input["batch_size"],
         )
 
     with rp_debugger.LineTimer('cleanup_step'):

--- a/src/rp_schema.py
+++ b/src/rp_schema.py
@@ -1,23 +1,28 @@
 INPUT_VALIDATIONS = {
     'audio': {
-        'type': str,
+        'type': str|None,
         'required': False,
         'default': None
     },
     'audio_base64': {
-        'type': str,
+        'type': str|None,
         'required': False,
         'default': None
     },
     'model': {
         'type': str,
         'required': False,
-        'default': 'base'
+        'default': 'large-v3'
     },
     'transcription': {
         'type': str,
         'required': False,
         'default': 'plain_text'
+    },
+    'multilingual': {
+        'type': bool,
+        'required': False,
+        'default': False
     },
     'translate': {
         'type': bool,
@@ -30,14 +35,14 @@ INPUT_VALIDATIONS = {
         'default': 'plain_text'
     },
     'language': {
-        'type': str,
+        'type': str|None,
         'required': False,
         'default': None
     },
     'temperature': {
         'type': float,
         'required': False,
-        'default': 0
+        'default': 0.0
     },
     'best_of': {
         'type': int,
@@ -57,7 +62,7 @@ INPUT_VALIDATIONS = {
     'length_penalty': {
         'type': float,
         'required': False,
-        'default': 0
+        'default': 0.0
     },
     'suppress_tokens': {
         'type': str,
@@ -65,7 +70,7 @@ INPUT_VALIDATIONS = {
         'default': '-1'
     },
     'initial_prompt': {
-        'type': str,
+        'type': str|None,
         'required': False,
         'default': None
     },
@@ -97,11 +102,16 @@ INPUT_VALIDATIONS = {
     'enable_vad': {
         'type': bool,
         'required': False,
-        'default': False
+        'default': True
     },
     'word_timestamps': {
         'type': bool,
         'required': False,
         'default': False
     },
+    'batch_size': {
+        'type': int,
+        'required': False,
+        'default': 8
+    }
 }


### PR DESCRIPTION
- Use CUDA 12.6 and Ubuntu 24.04
- Use venv
- Update to Faster Whisper 1.1.1
- Remove other than large-v3 and distil-large-v3 models to minimize container size
- Add `batch_size` and allow for faster parallel processing
- Make VAD used by default
- Add `multilingual` switch to allow for multilingual text and transcription
- Make `model` use `large-v3` as default model
- Fix schema data types to allow None for some string parameters