### PR TITLE
Upgrading faster_whisperer to 1.1.1 and a bunch of other fixes to the original worker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use specific version of nvidia cuda image
-FROM nvidia/cuda:11.7.1-cudnn8-runtime-ubuntu20.04
+FROM nvidia/cuda:12.3.2-cudnn9-runtime-ubuntu22.04
 
 # Remove any third-party apt sources to avoid issues with expiring keys.
 RUN rm -f /etc/apt/sources.list.d/*.list

--- a/builder/fetch_models.py
+++ b/builder/fetch_models.py
@@ -1,7 +1,7 @@
 from concurrent.futures import ThreadPoolExecutor
 from faster_whisper import WhisperModel
 
-model_names = ["tiny", "base", "small", "medium", "large-v1", "large-v2", "large-v3"]
+model_names = ["tiny"] #, "base", "small", "medium", "large-v1", "large-v2", "large-v3"]
 
 
 def load_model(selected_model):

--- a/builder/requirements.txt
+++ b/builder/requirements.txt
@@ -1,3 +1,3 @@
 runpod~=1.7.0
 
-faster-whisper==0.10.0
+faster-whisper==1.1.1

--- a/builder/requirements.txt
+++ b/builder/requirements.txt
@@ -1,3 +1,5 @@
 runpod~=1.7.0
 
 faster-whisper==1.1.1
+
+hf_xet==0.1.4

--- a/src/predict.py
+++ b/src/predict.py
@@ -30,7 +30,7 @@ class Predictor:
 
     def setup(self):
         """Load the model into memory to make running multiple predictions efficient"""
-        model_names = ["tiny", "base", "small", "medium", "large-v1", "large-v2", "large-v3"]
+        model_names = ["tiny"] # , "base", "small", "medium", "large-v1", "large-v2", "large-v3"]
         with ThreadPoolExecutor() as executor:
             for model_name, model in executor.map(self.load_model, model_names):
                 if model_name is not None:

--- a/src/rp_handler.py
+++ b/src/rp_handler.py
@@ -10,7 +10,12 @@ import tempfile
 
 from rp_schema import INPUT_VALIDATIONS
 from runpod.serverless.utils import download_files_from_urls, rp_cleanup, rp_debugger
-from runpod.serverless.utils.rp_validator import validate
+
+# Waiting for https://github.com/runpod/runpod-python/pull/401
+# to be merged into runpod-python. Meanwhile copying the file and fixing in place
+# from runpod.serverless.utils.rp_validator import validate 
+from rp_validator import validate
+
 import runpod
 import predict
 

--- a/src/rp_validator.py
+++ b/src/rp_validator.py
@@ -1,0 +1,121 @@
+"""
+runpod | serverless | utils | validator.py
+Provides a function to validate the input to the model.
+"""
+
+# pylint: disable=too-many-branches
+
+import json
+from typing import Any, Dict, List, Union
+
+# Error messages
+UNEXPECTED_INPUT_ERROR = "Unexpected input. {} is not a valid input option."
+MISSING_REQUIRED_ERROR = "{} is a required input."
+MISSING_DEFAULT_ERROR = "Schema error, missing default value for {}."
+MISSING_TYPE_ERROR = "Schema error, missing type for {}."
+#INVALID_TYPE_ERROR = "{} should be {} type, not {}."
+CONSTRAINTS_ERROR = "{} does not meet the constraints."
+SCHEMA_ERROR = "Schema error, {} is not a dictionary."
+
+
+def _add_error(error_list: List[str], message: str) -> None:
+    error_list.append(message)
+
+
+def _check_for_unexpected_inputs(raw_input, schema, error_list):
+    for key in raw_input:
+        if key not in schema:
+            _add_error(error_list, UNEXPECTED_INPUT_ERROR.format(key))
+
+
+def _validate_and_transform_schema_items(schema, error_list):
+    for key, rules in schema.items():
+        if not isinstance(rules, dict):
+            try:
+                schema[key] = json.loads(rules)
+            except json.decoder.JSONDecodeError:
+                _add_error(error_list, SCHEMA_ERROR.format(key))
+
+
+def _validate_required_inputs_and_set_defaults(
+    raw_input, schema, validated_input, error_list
+):
+    for key, rules in schema.items():
+        if "type" not in rules:
+            _add_error(error_list, MISSING_TYPE_ERROR.format(key))
+
+        if "required" not in rules:
+            _add_error(error_list, MISSING_REQUIRED_ERROR.format(key))
+        elif rules["required"] and key not in raw_input:
+            _add_error(error_list, MISSING_REQUIRED_ERROR.format(key))
+        elif not rules["required"] and key not in raw_input:
+            if "default" in rules:
+                validated_input[key] = rules["default"]
+            else:
+                _add_error(error_list, MISSING_DEFAULT_ERROR.format(key))
+
+
+def _validate_input_against_schema(schema, validated_input, error_list):
+    for key, rules in schema.items():
+        if key in validated_input:
+            # Enforce floats to be floats.
+            try:
+                if rules["type"] is float and type(validated_input[key]) in [
+                    int,
+                    float,
+                ]:
+                    validated_input[key] = float(validated_input[key])
+            except TypeError:
+                continue
+
+            # https://github.com/runpod/runpod-python/pull/401/commits/e7b57d60a87489d19b516fbe591736c6dc9d6f36
+            # skip type check assuming rare case, default value sets value
+            if "default" in rules and isinstance(validated_input[key], type(rules["default"])):
+                continue
+            
+            # Check for the correct type.
+            is_instance = isinstance(validated_input[key], rules["type"])
+            if not is_instance:
+                _add_error(
+                    error_list,
+                    f"{key} should be {rules['type']} type, not {type(validated_input[key])}.",
+                )
+
+        # Check lambda constraints.
+        if "constraints" in rules and not rules["constraints"](
+            validated_input.get(key)
+        ):
+            _add_error(error_list, CONSTRAINTS_ERROR.format(key))
+
+
+def validate(
+    raw_input: Dict[str, Any], schema: Dict[str, Any]
+) -> Dict[str, Union[Dict[str, Any], List[str]]]:
+    """
+    Validates the input.
+    Checks to see if the provided inputs match the expected types.
+    Checks to see if the required inputs are included.
+    Sets the default values for the inputs that are not provided.
+    Validates the inputs using the lambda constraints.
+
+    Returns either the list of errors or a validated_job_input.
+    {"errors": ["error1", "error2"]}
+    or
+    {"validated_input": {"input1": "value1", "input2": "value2"}
+    """
+    error_list = []
+    validated_input = raw_input.copy()
+
+    # Separate the process into functions for better readability
+    _check_for_unexpected_inputs(raw_input, schema, error_list)
+    _validate_and_transform_schema_items(schema, error_list)
+    _validate_required_inputs_and_set_defaults(
+        raw_input, schema, validated_input, error_list
+    )
+    _validate_input_against_schema(schema, validated_input, error_list)
+
+    validation_return = {"validated_input": validated_input}
+    if error_list:
+        validation_return = {"errors": error_list}
+
+    return validation_return


### PR DESCRIPTION
Switches to latest `faster-whisperer`, which in turn requires `nvidia/cuda:12.3.2-cudnn9-runtime-ubuntu22.04` as the Docker base.

Also pulled in a fix from runpod-python, which is not yet merged - otherwise the validation would not work.

Sample docker image (only with the `tiny` model) pushed as `fivetwosix/worker-faster_whisper:0.0.0`.