### PR TITLE
fix: update gpuIds to ADA_24

### DIFF
--- a/.runpod/hub.json
+++ b/.runpod/hub.json
@@ -7,7 +7,7 @@
   "config": {
     "runsOn": "GPU",
     "containerDiskInGb": 20,
-    "gpuIds": "NVIDIA GeForce RTX 4090",
+    "gpuIds": "ADA_24",
     "gpuCount": 1,
     "allowedCudaVersions": ["12.7", "12.6", "12.5", "12.4", "12.3"]
   }


### PR DESCRIPTION
### Motivation

- Updated gpuIds value to 'ADA_24' in .runpod/hub.json to ensure compatibility with the latest RunPod infrastructure

### Issues closed

- None