### PR TITLE
New faster-whisper variables: repetition_penalty and no_repeat_ngram_size

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@
 | `no_speech_threshold`               | float | If the probability of the token is higher than this value, consider the segment as silence. Default: 0.6                                                               |
 | `enable_vad`                        | bool  | If True, use the voice activity detection (VAD) to filter out parts of the audio without speech. This step is using the Silero VAD model. Default: False               |
 | `word_timestamps`                   | bool  | If True, include word timestamps in the output. Default: False                                                                                                         |
+| `repetition_penalty`                | float | To penalize the score of previously generated tokens (set > 1 to penalize). Default: 1.0                                                                               |
+| `no_repeat_ngram_size`              | int   | Prevent repetitions of ngrams with this size. Default: 0                                                                                                               |
 
 ### Example
 

--- a/src/predict.py
+++ b/src/predict.py
@@ -65,6 +65,8 @@ class Predictor:
         no_speech_threshold=0.6,
         enable_vad=False,
         word_timestamps=False,
+        repetition_penalty=1.0,
+        no_repeat_ngram_size=0,
     ):
         """
         Run a single prediction on the model, loading/unloading models as needed.
@@ -154,6 +156,8 @@ class Predictor:
                 max_initial_timestamp=1.0,
                 word_timestamps=word_timestamps,
                 vad_filter=enable_vad,
+                repetition_penalty=repetition_penalty,
+                no_repeat_ngram_size=no_repeat_ngram_size,
             )
         )
 

--- a/src/rp_handler.py
+++ b/src/rp_handler.py
@@ -89,7 +89,9 @@ def run_whisper_job(job):
             logprob_threshold=job_input["logprob_threshold"],
             no_speech_threshold=job_input["no_speech_threshold"],
             enable_vad=job_input["enable_vad"],
-            word_timestamps=job_input["word_timestamps"]
+            word_timestamps=job_input["word_timestamps"],
+            repetition_penalty=job_input["repetition_penalty"],
+            no_repeat_ngram_size=job_input["no_repeat_ngram_size"],
         )
 
     with rp_debugger.LineTimer('cleanup_step'):

--- a/src/rp_schema.py
+++ b/src/rp_schema.py
@@ -104,4 +104,14 @@ INPUT_VALIDATIONS = {
         'required': False,
         'default': False
     },
+    'repetition_penalty': {
+        'type': float,
+        'required': False,
+        'default': 1.0
+    },
+    'no_repeat_ngram_size': {
+        'type': int,
+        'required': False,
+        'default': 0
+    },
 }


### PR DESCRIPTION
New vars added so the faster-whisper runpod endpoint could read them from input request: `repetition_penalty` and `no_repeat_ngram_size`.

These are native faster-whisper vars. The code is tested, both vars proved to be working on runpod.