### PR TITLE
adding distil models to predict

### DIFF
--- a/src/predict.py
+++ b/src/predict.py
@@ -26,6 +26,8 @@ AVAILABLE_MODELS = {
     "large-v2",
     "large-v3",
     "turbo",
+    "distil-large-v2",
+    "distil-large-v3",
 }
 
 


### PR DESCRIPTION
Adding distil models to predict to solve this error:


{"requestId": null, "message": "{\n    \"error_type\": \"<class 'ValueError'>\",\n    \"error_message\": \"Invalid model name: distil-large-v3. Available models are: {'base', 'tiny', 'turbo', 'large-v3', 'large-v2', 'small', 'large-v1', 'medium'}\",\n    \"error_traceback\": \"Traceback (most recent call last):\\n  File \\\"/usr/local/lib/python3.10/dist-packages/runpod/serverless/modules/rp_job.py\\\", line 182, in run_job\\n    handler_return = handler(job)\\n  File \\\"/usr/local/lib/python3.10/dist-packages/runpod/serverless/utils/rp_debugger.py\\\", line 168, in __call__\\n    result = self.function(*args, **kwargs)\\n  File \\\"/rp_handler.py\\\", line 72, in run_whisper_job\\n    whisper_results = MODEL.predict(\\n  File \\\"/predict.py\\\", line 73, in predict\\n    raise ValueError(\\nValueError: Invalid model name: distil-large-v3. Available models are: {'base', 'tiny', 'turbo', 'large-v3', 'large-v2', 'small', 'large-v1', 'medium'}\\n\",\n    \"hostname\": \"d30i4egeu3vf07-64411289\",\n    \"worker_id\": \"d30i4egeu3vf07\",\n    \"runpod_version\": \"1.7.9\"\n}", "level": "ERROR"}
